### PR TITLE
Support custom default database name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,13 +9,13 @@
     <name>ClackShack</name>
     <url>https://github.com/ethlo/clackshack</url>
     <description>Unofficial ClickHouse HTTP query interface client</description>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.7.3</version>
+                <version>2.7.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/com/ethlo/clackshack/ClackShackImpl.java
+++ b/src/main/java/com/ethlo/clackshack/ClackShackImpl.java
@@ -87,6 +87,7 @@ public class ClackShackImpl implements ClackShack
     {
         this(baseUrl, null);
     }
+
     public ClackShackImpl(String baseUrl, final String database)
     {
         this.baseUrl = baseUrl;
@@ -262,7 +263,12 @@ public class ClackShackImpl implements ClackShack
 
             return response;
         }
-        catch (InterruptedException | TimeoutException exc)
+        catch (InterruptedException exc)
+        {
+            Thread.currentThread().interrupt();
+            throw new UncheckedIOException(new IOException(exc));
+        }
+        catch (TimeoutException exc)
         {
             throw new UncheckedIOException(new IOException(exc));
         }

--- a/src/main/java/com/ethlo/clackshack/QueryOptions.java
+++ b/src/main/java/com/ethlo/clackshack/QueryOptions.java
@@ -25,15 +25,17 @@ import java.util.Optional;
 
 public class QueryOptions
 {
-    public static final QueryOptions DEFAULT = new QueryOptions(null, false, null, null);
+    public static final QueryOptions DEFAULT = new QueryOptions(null, null, false, null, null);
 
+    private final String database;
     private final String queryId;
     private final boolean replaceQuery;
     private final Duration maxExecutionTime;
     private final QueryProgressListener progressListener;
 
-    public QueryOptions(final String queryId, final boolean replaceQuery, final Duration maxExecutionTime, final QueryProgressListener progressListener)
+    public QueryOptions(final String database, final String queryId, final boolean replaceQuery, final Duration maxExecutionTime, final QueryProgressListener progressListener)
     {
+        this.database = database;
         this.queryId = queryId;
         this.replaceQuery = replaceQuery;
         this.maxExecutionTime = maxExecutionTime;
@@ -75,6 +77,11 @@ public class QueryOptions
         return Optional.ofNullable(queryId);
     }
 
+    public Optional<String> getDatabase()
+    {
+        return Optional.ofNullable(database);
+    }
+
     /**
      * A progress listener that will be called every time ClickHouse provides an updated progress header
      *
@@ -87,17 +94,17 @@ public class QueryOptions
 
     public QueryOptions progressListener(QueryProgressListener progressListener)
     {
-        return new QueryOptions(this.queryId, this.replaceQuery, this.maxExecutionTime, progressListener);
+        return new QueryOptions(this.database, this.queryId, this.replaceQuery, this.maxExecutionTime, progressListener);
     }
 
     public QueryOptions queryId(final String queryId)
     {
-        return new QueryOptions(queryId, this.replaceQuery, this.maxExecutionTime, progressListener);
+        return new QueryOptions(this.database, queryId, this.replaceQuery, this.maxExecutionTime, progressListener);
     }
 
     public QueryOptions maxExecutionTime(final Duration maxExecutionTime)
     {
-        return new QueryOptions(queryId, this.replaceQuery, maxExecutionTime, progressListener);
+        return new QueryOptions(this.database, queryId, this.replaceQuery, maxExecutionTime, progressListener);
     }
 
     public QueryOptions replaceQuery(final boolean replaceQuery)
@@ -106,6 +113,11 @@ public class QueryOptions
         {
             throw new IllegalStateException("queryId is required when using replaceQuery");
         }
-        return new QueryOptions(this.queryId, replaceQuery, maxExecutionTime, progressListener);
+        return new QueryOptions(this.database, this.queryId, replaceQuery, maxExecutionTime, progressListener);
+    }
+
+    public QueryOptions database(String database)
+    {
+        return new QueryOptions(database, this.queryId, this.replaceQuery, this.maxExecutionTime, this.progressListener);
     }
 }

--- a/src/test/java/com/ethlo/clackshack/ClientTest.java
+++ b/src/test/java/com/ethlo/clackshack/ClientTest.java
@@ -138,7 +138,7 @@ public class ClientTest
         {
             final String queryId = UUID.randomUUID().toString();
             final String query = "SELECT count() from numbers(200000000000)";
-            final AtomicReference<Exception> exceptionRef = runInSeparateThreadAnfFetchException(clackShack, query, QueryOptions.create().queryId(queryId));
+            final AtomicReference<Exception> exceptionRef = runInSeparateThreadAndFetchException(clackShack, query, QueryOptions.create().queryId(queryId));
 
             Thread.sleep(100);
             clackShack.killQuery(queryId);
@@ -233,7 +233,7 @@ public class ClientTest
             final String queryId = UUID.randomUUID().toString();
             final String query = "SELECT count() from numbers(100000000000)";
             final QueryOptions options = QueryOptions.create().queryId(queryId);
-            runInSeparateThreadAnfFetchException(clackShack, query, options);
+            runInSeparateThreadAndFetchException(clackShack, query, options);
             Thread.sleep(100);
 
             // Same query again, with same id
@@ -261,7 +261,7 @@ public class ClientTest
             final String queryId = UUID.randomUUID().toString();
 
             final String query = "SELECT count() from numbers(3000000000)";
-            final AtomicReference<Exception> exceptionRef = runInSeparateThreadAnfFetchException(clackShack, query, QueryOptions.create()
+            final AtomicReference<Exception> exceptionRef = runInSeparateThreadAndFetchException(clackShack, query, QueryOptions.create()
                     .queryId(queryId)
                     .progressListener(QueryProgressListener.LOGGER));
 
@@ -277,7 +277,7 @@ public class ClientTest
         }
     }
 
-    private AtomicReference<Exception> runInSeparateThreadAnfFetchException(ClackShack clackShack, String query, QueryOptions queryId)
+    private AtomicReference<Exception> runInSeparateThreadAndFetchException(ClackShack clackShack, String query, QueryOptions queryId)
     {
         final AtomicReference<Exception> exceptionRef = new AtomicReference<>();
         new Thread()


### PR DESCRIPTION
We need to be able to put what is the current database to work with. 
This can either be set via QueryOptions per query or default when constructing a new ClackShackImpl